### PR TITLE
Implement ACM GitOps integration for automated ArgoCD cluster registr…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ The codebase is organized into several key components:
 - `regional-deployments/`: Regional service configurations
 - `prereqs/`: Prerequisites for bootstrap process
 - `pipelines/`: Tekton pipeline configurations
+- `acm-gitops/`: ACM GitOps integration with automated ArgoCD cluster registration
 
 ## Common Commands
 
@@ -123,6 +124,22 @@ Currently uses manual secret management (Vault integration planned):
 oc get secret aws-creds -n $cluster_namespace -o yaml > secrets/aws-creds.yaml
 oc get secret pull-secret -n $cluster_namespace -o yaml > secrets/pull-secret.yaml
 ```
+
+## ACM GitOps Integration
+
+The project uses ACM's native GitOps integration to automatically register ManagedClusters with ArgoCD:
+
+### Components
+- **GitOpsCluster CR**: Automatically registers clusters with ArgoCD based on Placement selection
+- **ManagedClusterSetBinding**: Binds the global ManagedClusterSet to openshift-gitops namespace
+- **Placement**: Selects clusters based on labels (OpenShift + Amazon)
+- **Policy**: Automates the creation of GitOps resources across clusters
+
+### Features
+- **Automated Cluster Registration**: No manual ArgoCD secret management required
+- **ApplicationManager Integration**: KlusterletAddonConfig enables ArgoCD permissions on target clusters
+- **Policy-Driven**: ACM policies ensure consistent GitOps configuration across all clusters
+- **Label-Based Selection**: Clusters are automatically included based on vendor=OpenShift, cloud=Amazon labels
 
 ## Development Best Practices
 

--- a/acm-gitops/base/gitopscluster.yaml
+++ b/acm-gitops/base/gitopscluster.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps.open-cluster-management.io/v1beta1
+kind: GitOpsCluster
+metadata:
+  name: gitops-cluster
+  namespace: openshift-gitops
+spec:
+  argoServer:
+    cluster: local-cluster
+    argoNamespace: openshift-gitops
+  placementRef:
+    kind: Placement
+    apiVersion: cluster.open-cluster-management.io/v1beta1
+    name: gitops-cluster-placement

--- a/acm-gitops/base/kustomization.yaml
+++ b/acm-gitops/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - managedclustersetbinding.yaml
+  - placement.yaml
+  - gitopscluster.yaml

--- a/acm-gitops/base/managedclustersetbinding.yaml
+++ b/acm-gitops/base/managedclustersetbinding.yaml
@@ -1,0 +1,7 @@
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSetBinding
+metadata:
+  name: global
+  namespace: openshift-gitops
+spec:
+  clusterSet: global

--- a/acm-gitops/base/placement.yaml
+++ b/acm-gitops/base/placement.yaml
@@ -1,0 +1,14 @@
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
+metadata:
+  name: gitops-cluster-placement
+  namespace: openshift-gitops
+spec:
+  clusterSets:
+    - global
+  predicates:
+    - requiredClusterSelector:
+        labelSelector:
+          matchLabels:
+            vendor: OpenShift
+            cloud: Amazon

--- a/acm-gitops/kustomization.yaml
+++ b/acm-gitops/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - base
+  - policies

--- a/acm-gitops/policies/gitops-integration-policy.yaml
+++ b/acm-gitops/policies/gitops-integration-policy.yaml
@@ -1,0 +1,107 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: gitops-integration-policy
+  namespace: open-cluster-management-policies
+  annotations:
+    policy.open-cluster-management.io/standards: NIST-CSF
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: gitops-managedclustersetbinding
+        spec:
+          remediationAction: enforce
+          severity: medium
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: cluster.open-cluster-management.io/v1beta2
+                kind: ManagedClusterSetBinding
+                metadata:
+                  name: global
+                  namespace: openshift-gitops
+                spec:
+                  clusterSet: global
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: gitops-placement
+        spec:
+          remediationAction: enforce
+          severity: medium
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: cluster.open-cluster-management.io/v1beta1
+                kind: Placement
+                metadata:
+                  name: gitops-cluster-placement
+                  namespace: openshift-gitops
+                spec:
+                  clusterSets:
+                    - global
+                  predicates:
+                    - requiredClusterSelector:
+                        labelSelector:
+                          matchLabels:
+                            vendor: OpenShift
+                            cloud: Amazon
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: gitops-cluster
+        spec:
+          remediationAction: enforce
+          severity: medium
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: apps.open-cluster-management.io/v1beta1
+                kind: GitOpsCluster
+                metadata:
+                  name: gitops-cluster
+                  namespace: openshift-gitops
+                spec:
+                  argoServer:
+                    cluster: local-cluster
+                    argoNamespace: openshift-gitops
+                  placementRef:
+                    kind: Placement
+                    apiVersion: cluster.open-cluster-management.io/v1beta1
+                    name: gitops-cluster-placement
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: gitops-integration-policy-binding
+  namespace: open-cluster-management-policies
+placementRef:
+  name: gitops-integration-policy-placement
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: gitops-integration-policy
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: gitops-integration-policy-placement
+  namespace: open-cluster-management-policies
+spec:
+  clusterConditions:
+    - status: "True"
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchLabels:
+      name: local-cluster

--- a/acm-gitops/policies/kustomization.yaml
+++ b/acm-gitops/policies/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - gitops-integration-policy.yaml

--- a/gitops-applications/acm-gitops-integration.application.yaml
+++ b/gitops-applications/acm-gitops-integration.application.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: acm-gitops-integration
+  namespace: openshift-gitops
+spec:
+  destination:
+    name: in-cluster
+  project: default
+  source:
+    path: acm-gitops
+    repoURL: 'https://github.com/openshift-online/bootstrap'
+    targetRevision: main
+  syncPolicy:
+    automated:
+      selfHeal: true
+      allowEmpty: false
+    prune: true

--- a/gitops-applications/kustomization.yaml
+++ b/gitops-applications/kustomization.yaml
@@ -10,5 +10,6 @@ resources:
 - ./eso.application.yaml
 - ./regional-clusters.cluster-10.application.yaml
 - ./regional-deployments.cluster-10.application.yaml
+- ./acm-gitops-integration.application.yaml
 #- ./regional-pipelines.cluster-10.application.yaml
 


### PR DESCRIPTION
…ation

- Add acm-gitops/ directory with GitOpsCluster CR and supporting resources
- Create ManagedClusterSetBinding for global clusterset access in openshift-gitops
- Add Placement to select OpenShift+Amazon clusters for GitOps integration
- Implement Policy-based automation for consistent GitOps configuration
- Add ArgoCD Application for acm-gitops-integration deployment
- Update CLAUDE.md with ACM GitOps Integration documentation

Features:
- Automated cluster registration eliminates manual ArgoCD secret management
- Policy-driven approach ensures consistent GitOps setup across all clusters
- Label-based cluster selection (vendor=OpenShift, cloud=Amazon)
- Leverages existing KlusterletAddonConfig applicationManager integration

Resources created:
- GitOpsCluster CR for automated ArgoCD registration
- ManagedClusterSetBinding for global clusterset binding
- Placement for OpenShift+Amazon cluster selection
- Policy for automated GitOps resource creation
- ArgoCD Application for deployment

🤖 Generated with [Claude Code](https://claude.ai/code)