### PR TITLE
Update EKS CAPI resources to use v1beta2 API versions

### DIFF
--- a/clusters/overlay/cluster-40/awsmanagedcontrolplane.yaml
+++ b/clusters/overlay/cluster-40/awsmanagedcontrolplane.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: AWSManagedControlPlane
 metadata:
   name: cluster-40

--- a/clusters/overlay/cluster-40/awsmanagedmachinepool.yaml
+++ b/clusters/overlay/cluster-40/awsmanagedmachinepool.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSManagedMachinePool
 metadata:
   name: cluster-40-worker

--- a/clusters/overlay/cluster-40/cluster.yaml
+++ b/clusters/overlay/cluster-40/cluster.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: cluster-40
@@ -9,10 +9,10 @@ spec:
     pods:
       cidrBlocks: ["192.168.0.0/16"]
   infrastructureRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     kind: AWSManagedControlPlane
     name: cluster-40
   controlPlaneRef:
     kind: AWSManagedControlPlane
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta2
     name: cluster-40

--- a/clusters/overlay/cluster-40/machinepool.yaml
+++ b/clusters/overlay/cluster-40/machinepool.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachinePool
 metadata:
   name: cluster-40-worker
@@ -13,6 +13,6 @@ spec:
       bootstrap:
         dataSecretName: ""
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: AWSManagedMachinePool
         name: cluster-40-worker


### PR DESCRIPTION
- Update AWSManagedControlPlane from v1beta1 to v1beta2
- Update AWSManagedMachinePool from v1beta1 to v1beta2
- Update Cluster and MachinePool references to v1beta2
- Ensures compatibility with latest CAPI EKS provider

🤖 Generated with [Claude Code](https://claude.ai/code)