### PR TITLE
Fix regional deployments for spoke clusters

### DIFF
--- a/regional-deployments/base/kustomization.yaml
+++ b/regional-deployments/base/kustomization.yaml
@@ -5,6 +5,7 @@ commonAnnotations:
   version: "v0.0.1"
 
 resources:
+  - ../../operators/openshift-pipelines/operator/overlays/pipelines-1.18
   - ams.db.yaml
   - cs.db.yaml
   - osl.db.yaml

--- a/regional-deployments/overlays/cluster-10/namespace.yaml
+++ b/regional-deployments/overlays/cluster-10/namespace.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: ocm-cluster-10
+  annotations:
+    openshift.io/display-name: "OpenShift Cluster Management - cluster-10"
+  labels:
+    argocd.argoproj.io/managed-by: openshift-gitops
+    openshift.io/cluster-monitoring: "true"


### PR DESCRIPTION
  - Remove ACM from regional deployments base to avoid MultiClusterHub conflicts
  - Add proper namespace for cluster-10 with monitoring and ArgoCD labels
  - Regional deployments now only include Pipelines operator and services