### PR TITLE
Move OpenShift Pipelines operator to pipelines base

### DIFF
--- a/pipelines/base/kustomization.yaml
+++ b/pipelines/base/kustomization.yaml
@@ -5,5 +5,6 @@ commonAnnotations:
   version: "v0.0.1"
 
 resources:
+  - ../../operators/openshift-pipelines/operator/overlays/pipelines-1.18
   - cloud-infrastructure-provisioning.pipeline.yaml
 

--- a/regional-deployments/base/kustomization.yaml
+++ b/regional-deployments/base/kustomization.yaml
@@ -5,7 +5,6 @@ commonAnnotations:
   version: "v0.0.1"
 
 resources:
-  - ../../operators/openshift-pipelines/operator/overlays/pipelines-1.18
   - ams.db.yaml
   - cs.db.yaml
   - osl.db.yaml


### PR DESCRIPTION
Fix timing issue where Pipeline CRDs were not available during sync. Moves operator installation from regional-deployments to pipelines/base so CRDs are installed before Pipeline resources are deployed.

🤖 Generated with [Claude Code](https://claude.ai/code)