### PR TITLE
Create operator-only overlay to fix SharedResourceWarning

### DIFF
--- a/operators/openshift-pipelines/operator/overlays/pipelines-operator-only/kustomization.yaml
+++ b/operators/openshift-pipelines/operator/overlays/pipelines-operator-only/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base/subscription.yaml
+
+patches:
+  - path: patch-channel.yaml
+    target:
+      group: operators.coreos.com
+      kind: Subscription
+      name: openshift-pipelines-operator
+      namespace: openshift-operators
+      version: v1alpha1

--- a/operators/openshift-pipelines/operator/overlays/pipelines-operator-only/patch-channel.yaml
+++ b/operators/openshift-pipelines/operator/overlays/pipelines-operator-only/patch-channel.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/channel
+  value: pipelines-1.18

--- a/pipelines/base/kustomization.yaml
+++ b/pipelines/base/kustomization.yaml
@@ -5,6 +5,6 @@ commonAnnotations:
   version: "v0.0.1"
 
 resources:
-  - ../../operators/openshift-pipelines/operator/overlays/pipelines-1.18
+  - ../../operators/openshift-pipelines/operator/overlays/pipelines-operator-only
   - cloud-infrastructure-provisioning.pipeline.yaml
 


### PR DESCRIPTION
Add pipelines-operator-only overlay that deploys only the OpenShift Pipelines operator without console plugin components. This prevents resource conflicts when both pipelines and regional-deployments applications manage the same Tekton console plugin resources.

🤖 Generated with [Claude Code](https://claude.ai/code)