### PR TITLE
Fix kustomization path security issue and add validation commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,4 +288,18 @@ An interactive test plan is available at `NEWREGION.md` that guides through crea
 - Test overlays before applying to clusters
 - Follow GitOps principles for all cluster modifications
 - Reference existing cluster overlays (cluster-10, region-02, region-03) as templates
+
+### Validation Commands
+
+```bash
+# Validate kustomization builds
+oc kustomize pipelines/overlays/cluster-10/
+oc kustomize clusters/overlay/cluster-10/
+oc kustomize regional-deployments/overlays/cluster-10/
+
+# Dry-run validation (recommended)
+oc --dry-run=client apply -k pipelines/overlays/cluster-10/
+oc --dry-run=client apply -k clusters/overlay/cluster-10/
+oc --dry-run=client apply -k regional-deployments/overlays/cluster-10/
+```
 ```

--- a/operators/openshift-pipelines/operator/overlays/pipelines-operator-only/kustomization.yaml
+++ b/operators/openshift-pipelines/operator/overlays/pipelines-operator-only/kustomization.yaml
@@ -2,8 +2,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: openshift-operators
+
 resources:
-  - ../../base/subscription.yaml
+  - subscription.yaml
 
 patches:
   - path: patch-channel.yaml

--- a/operators/openshift-pipelines/operator/overlays/pipelines-operator-only/subscription.yaml
+++ b/operators/openshift-pipelines/operator/overlays/pipelines-operator-only/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-pipelines-operator
+  namespace: openshift-operators
+spec:
+  channel: patch-me-see-overlays-dir
+  installPlanApproval: Automatic
+  name: openshift-pipelines-operator-rh
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Fix pipelines-operator-only overlay to use local subscription.yaml file instead of referencing files outside the overlay directory. This resolves kustomize security policy violations during ArgoCD sync operations.

Add validation commands section to CLAUDE.md with examples for testing overlays using both kustomize build and dry-run apply.

🤖 Generated with [Claude Code](https://claude.ai/code)