### PR TITLE
Fix cluster-20 pipeline sync issues and update documentation

### DIFF
--- a/clusters/cluster-20/kustomization.yaml
+++ b/clusters/cluster-20/kustomization.yaml
@@ -62,6 +62,9 @@ patches:
       - op: replace
         path: /metadata/name
         value: cluster-20-worker
+      - op: replace
+        path: /spec/platform/aws/zones/0
+        value: us-east-1a
   - target:
       kind: KlusterletAddonConfig
       version: v1

--- a/gitops-applications/cluster-20.yaml
+++ b/gitops-applications/cluster-20.yaml
@@ -38,7 +38,7 @@ spec:
       source:
         repoURL: 'https://github.com/openshift-online/bootstrap'
         path: '{{path}}'
-        targetRevision: main
+        targetRevision: OCM-16599/capi_poc
       syncPolicy:
         automated:
           selfHeal: true

--- a/operators/openshift-pipelines/cluster-10/kustomization.yaml
+++ b/operators/openshift-pipelines/cluster-10/kustomization.yaml
@@ -9,5 +9,5 @@ commonAnnotations:
   version: "v0.0.1"
 
 resources:
-  - ../openshift-pipelines/operator/overlays/pipelines-operator-only
+  - ../operator/overlays/pipelines-operator-only
   - namespace.yaml

--- a/operators/openshift-pipelines/cluster-20/kustomization.yaml
+++ b/operators/openshift-pipelines/cluster-20/kustomization.yaml
@@ -9,5 +9,5 @@ commonAnnotations:
   version: "v0.0.1"
 
 resources:
-  - ../openshift-pipelines/operator/overlays/pipelines-operator-only
+  - ../operator/overlays/pipelines-operator-only
   - namespace.yaml

--- a/operators/openshift-pipelines/cluster-30/kustomization.yaml
+++ b/operators/openshift-pipelines/cluster-30/kustomization.yaml
@@ -9,5 +9,5 @@ commonAnnotations:
   version: "v0.0.1"
 
 resources:
-  - ../openshift-pipelines/operator/overlays/pipelines-operator-only
+  - ../operator/overlays/pipelines-operator-only
   - namespace.yaml


### PR DESCRIPTION
- Fix operator kustomization paths for all clusters (removed duplicate openshift-pipelines path)
- Update cluster-20 GitOps application to use OCM-16599/capi_poc branch
- Add cluster-20 worker node zone fix to kustomization patches
- Update CLAUDE.md with recent session fixes and current cluster status
- Add sync wave ordering documentation and generate-cluster script updates

🤖 Generated with [Claude Code](https://claude.ai/code)