### PR TITLE
Update cluster destination URLs to use default Kubernetes service end…

### DIFF
--- a/bin/generate-cluster
+++ b/bin/generate-cluster
@@ -1143,19 +1143,19 @@ spec:
         syncWave: "1"
       - component: operators
         path: operators/openshift-pipelines/$FULL_CLUSTER_NAME
-        destination: https://api.$FULL_CLUSTER_NAME.rosa.mturansk-test.csu2.i3.devshift.org:6443
+        destination: https://kubernetes.default.svc
         syncWave: "2"
       - component: pipelines-hello-world
         path: pipelines/hello-world/$FULL_CLUSTER_NAME
-        destination: $(if [ "$CLUSTER_TYPE" = "ocp" ]; then echo "https://api.$FULL_CLUSTER_NAME.rosa.mturansk-test.csu2.i3.devshift.org:6443"; else echo "https://managed-$FULL_CLUSTER_NAME-$REGION.eks.amazonaws.com"; fi)
+        destination: https://kubernetes.default.svc
         syncWave: "3"
       - component: pipelines-cloud-infrastructure-provisioning
         path: pipelines/cloud-infrastructure-provisioning/$FULL_CLUSTER_NAME
-        destination: $(if [ "$CLUSTER_TYPE" = "ocp" ]; then echo "https://api.$FULL_CLUSTER_NAME.rosa.mturansk-test.csu2.i3.devshift.org:6443"; else echo "https://managed-$FULL_CLUSTER_NAME-$REGION.eks.amazonaws.com"; fi)
+        destination: https://kubernetes.default.svc
         syncWave: "3"
       - component: deployments-ocm
         path: deployments/ocm/$FULL_CLUSTER_NAME
-        destination: $(if [ "$CLUSTER_TYPE" = "ocp" ]; then echo "https://api.$FULL_CLUSTER_NAME.rosa.mturansk-test.csu2.i3.devshift.org:6443"; else echo "https://managed-$FULL_CLUSTER_NAME-$REGION.eks.amazonaws.com"; fi)
+        destination: https://kubernetes.default.svc
         syncWave: "4"
   template:
     metadata:

--- a/gitops-applications/ocp-01-mturansk-test222.yaml
+++ b/gitops-applications/ocp-01-mturansk-test222.yaml
@@ -13,19 +13,19 @@ spec:
         syncWave: "1"
       - component: operators
         path: operators/openshift-pipelines/ocp-01-mturansk-test222
-        destination: https://api.ocp-01-mturansk-test222.rosa.mturansk-test.csu2.i3.devshift.org:6443
+        destination: https://kubernetes.default.svc
         syncWave: "2"
       - component: pipelines-hello-world
         path: pipelines/hello-world/ocp-01-mturansk-test222
-        destination: https://api.ocp-01-mturansk-test222.rosa.mturansk-test.csu2.i3.devshift.org:6443
+        destination: https://kubernetes.default.svc
         syncWave: "3"
       - component: pipelines-cloud-infrastructure-provisioning
         path: pipelines/cloud-infrastructure-provisioning/ocp-01-mturansk-test222
-        destination: https://api.ocp-01-mturansk-test222.rosa.mturansk-test.csu2.i3.devshift.org:6443
+        destination: https://kubernetes.default.svc
         syncWave: "3"
       - component: deployments-ocm
         path: deployments/ocm/ocp-01-mturansk-test222
-        destination: https://api.ocp-01-mturansk-test222.rosa.mturansk-test.csu2.i3.devshift.org:6443
+        destination: https://kubernetes.default.svc
         syncWave: "4"
   template:
     metadata:


### PR DESCRIPTION
…point

Replace hardcoded cluster-specific API endpoints with https://kubernetes.default.svc for improved portability and configuration management.

🤖 Generated with [Claude Code](https://claude.ai/code)