### PR TITLE
Fix external-secrets template structure

### DIFF
--- a/bases/clusters/external-secrets.yaml
+++ b/bases/clusters/external-secrets.yaml
@@ -35,7 +35,8 @@ spec:
   target:
     name: pull-secret
     creationPolicy: Owner
-    type: kubernetes.io/dockerconfigjson
+    template:
+      type: kubernetes.io/dockerconfigjson
   data:
   - secretKey: .dockerconfigjson
     remoteRef:

--- a/clusters/ocp-01-mturan-test/kustomization.yaml
+++ b/clusters/ocp-01-mturan-test/kustomization.yaml
@@ -101,5 +101,5 @@ patches:
         path: /metadata/namespace
         value: ocp-01-mturan-test
       - op: replace
-        path: /spec/target/type
+        path: /spec/target/template/type
         value: kubernetes.io/dockerconfigjson


### PR DESCRIPTION
Move type field to spec.target.template.type in both base configuration and cluster-specific patch to match ExternalSecret API requirements.

🤖 Generated with [Claude Code](https://claude.ai/code)