### PR TITLE
Rename cluster ocp-01-mturansk-test to ocp-01-mturansk-a1 and fix boo…

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -40,4 +40,4 @@ echo ""
 
 echo "Setting up Vault-based secret management for provisioned cluster namespaces"
 echo "Note: ExternalSecrets will be created but won't sync until clusters are fully provisioned"
-./bin/bootstrap.vault-integration.sh
+./bin/bootstrap.vault

--- a/clusters/ocp-01-mturansk-a1/install-config.yaml
+++ b/clusters/ocp-01-mturansk-a1/install-config.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 metadata:
-  name: 'ocp-01-mturansk-test'
+  name: 'ocp-01-mturansk-a1'
 baseDomain: rosa.mturansk-test.csu2.i3.devshift.org
 controlPlane:
   architecture: amd64

--- a/clusters/ocp-01-mturansk-a1/klusterletaddonconfig.yaml
+++ b/clusters/ocp-01-mturansk-a1/klusterletaddonconfig.yaml
@@ -1,8 +1,8 @@
 apiVersion: agent.open-cluster-management.io/v1
 kind: KlusterletAddonConfig
 metadata:
-  name: ocp-01-mturansk-test
-  namespace: ocp-01-mturansk-test
+  name: ocp-01-mturansk-a1
+  namespace: ocp-01-mturansk-a1
 spec:
   applicationManager:
     enabled: true
@@ -10,11 +10,11 @@ spec:
     enabled: true
   clusterLabels:
     cloud: Amazon
-    name: ocp-01-mturansk-test
+    name: ocp-01-mturansk-a1
     vendor: OpenShift
     region: us-west-2
-  clusterName: ocp-01-mturansk-test
-  clusterNamespace: ocp-01-mturansk-test
+  clusterName: ocp-01-mturansk-a1
+  clusterNamespace: ocp-01-mturansk-a1
   policyController:
     enabled: true
   searchCollector:

--- a/clusters/ocp-01-mturansk-a1/kustomization.yaml
+++ b/clusters/ocp-01-mturansk-a1/kustomization.yaml
@@ -12,7 +12,7 @@ generatorOptions:
 
 secretGenerator:
   - name: install-config
-    namespace: ocp-01-mturansk-test
+    namespace: ocp-01-mturansk-a1
     files:
       - install-config.yaml
 
@@ -24,13 +24,13 @@ patches:
     patch: |
       - op: replace
         path: /metadata/namespace
-        value: ocp-01-mturansk-test
+        value: ocp-01-mturansk-a1
       - op: replace
         path: /metadata/name
-        value: ocp-01-mturansk-test
+        value: ocp-01-mturansk-a1
       - op: replace
         path: /spec/clusterName
-        value: ocp-01-mturansk-test
+        value: ocp-01-mturansk-a1
       - op: replace
         path: /spec/platform/aws/region
         value: us-west-2
@@ -41,13 +41,13 @@ patches:
     patch: |
       - op: replace
         path: /metadata/namespace
-        value: ocp-01-mturansk-test
+        value: ocp-01-mturansk-a1
       - op: replace
         path: /metadata/name
-        value: ocp-01-mturansk-test
+        value: ocp-01-mturansk-a1
       - op: replace
         path: /metadata/labels/name
-        value: ocp-01-mturansk-test
+        value: ocp-01-mturansk-a1
       - op: replace
         path: /metadata/labels/region
         value: us-west-2
@@ -58,13 +58,13 @@ patches:
     patch: |
       - op: replace
         path: /metadata/namespace
-        value: ocp-01-mturansk-test
+        value: ocp-01-mturansk-a1
       - op: replace
         path: /spec/clusterDeploymentRef/name
-        value: ocp-01-mturansk-test
+        value: ocp-01-mturansk-a1
       - op: replace
         path: /metadata/name
-        value: ocp-01-mturansk-test-worker
+        value: ocp-01-mturansk-a1-worker
   - target:
       kind: KlusterletAddonConfig
       version: v1
@@ -72,19 +72,19 @@ patches:
     patch: |
       - op: replace
         path: /metadata/namespace
-        value: ocp-01-mturansk-test
+        value: ocp-01-mturansk-a1
       - op: replace
         path: /metadata/name
-        value: ocp-01-mturansk-test
+        value: ocp-01-mturansk-a1
       - op: replace
         path: /spec/clusterLabels/name
-        value: ocp-01-mturansk-test
+        value: ocp-01-mturansk-a1
       - op: replace
         path: /spec/clusterNamespace
-        value: ocp-01-mturansk-test
+        value: ocp-01-mturansk-a1
       - op: replace
         path: /spec/clusterName
-        value: ocp-01-mturansk-test
+        value: ocp-01-mturansk-a1
   - target:
       kind: ExternalSecret
       version: v1
@@ -93,7 +93,7 @@ patches:
     patch: |
       - op: replace
         path: /metadata/namespace
-        value: ocp-01-mturansk-test
+        value: ocp-01-mturansk-a1
   - target:
       kind: ExternalSecret
       version: v1
@@ -102,7 +102,7 @@ patches:
     patch: |
       - op: replace
         path: /metadata/namespace
-        value: ocp-01-mturansk-test
+        value: ocp-01-mturansk-a1
       - op: replace
         path: /spec/target/template/type
         value: kubernetes.io/dockerconfigjson

--- a/clusters/ocp-01-mturansk-a1/namespace.yaml
+++ b/clusters/ocp-01-mturansk-a1/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ocp-01-mturansk-a1
+  labels:
+    name: ocp-01-mturansk-a1

--- a/clusters/ocp-01-mturansk-test/namespace.yaml
+++ b/clusters/ocp-01-mturansk-test/namespace.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: ocp-01-mturansk-test
-  labels:
-    name: ocp-01-mturansk-test

--- a/deployments/ocm/ocp-01-mturansk-a1/kustomization.yaml
+++ b/deployments/ocm/ocp-01-mturansk-a1/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: ocm-ocp-01-mturansk-test
+namespace: ocm-ocp-01-mturansk-a1
 
 resources:
   - ../../../bases/ocm

--- a/deployments/ocm/ocp-01-mturansk-a1/namespace.yaml
+++ b/deployments/ocm/ocp-01-mturansk-a1/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ocm-ocp-01-mturansk-a1
+  labels:
+    name: ocm-ocp-01-mturansk-a1

--- a/deployments/ocm/ocp-01-mturansk-test/namespace.yaml
+++ b/deployments/ocm/ocp-01-mturansk-test/namespace.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: ocm-ocp-01-mturansk-test
-  labels:
-    name: ocm-ocp-01-mturansk-test

--- a/gitops-applications/kustomization.yaml
+++ b/gitops-applications/kustomization.yaml
@@ -14,7 +14,8 @@ resources:
 
 # ADD CLUSTERS HERE
 
-- ./ocp-01-mturansk-test.yaml
+- ./ocp-01-mturansk-a1.yaml
+
 
 
 

--- a/gitops-applications/ocp-01-mturansk-a1.yaml
+++ b/gitops-applications/ocp-01-mturansk-a1.yaml
@@ -1,35 +1,35 @@
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
-  name: ocp-01-mturansk-test-applications
+  name: ocp-01-mturansk-a1-applications
   namespace: openshift-gitops
 spec:
   generators:
   - list:
       elements:
       - component: cluster
-        path: clusters/ocp-01-mturansk-test
+        path: clusters/ocp-01-mturansk-a1
         destination: https://kubernetes.default.svc
         syncWave: "1"
       - component: operators
-        path: operators/openshift-pipelines/ocp-01-mturansk-test
-        destination: ocp-01-mturansk-test
+        path: operators/openshift-pipelines/ocp-01-mturansk-a1
+        destination: ocp-01-mturansk-a1
         syncWave: "2"
       - component: pipelines-hello-world
-        path: pipelines/hello-world/ocp-01-mturansk-test
-        destination: ocp-01-mturansk-test
+        path: pipelines/hello-world/ocp-01-mturansk-a1
+        destination: ocp-01-mturansk-a1
         syncWave: "3"
       - component: pipelines-cloud-infrastructure-provisioning
-        path: pipelines/cloud-infrastructure-provisioning/ocp-01-mturansk-test
-        destination: ocp-01-mturansk-test
+        path: pipelines/cloud-infrastructure-provisioning/ocp-01-mturansk-a1
+        destination: ocp-01-mturansk-a1
         syncWave: "3"
       - component: deployments-ocm
-        path: deployments/ocm/ocp-01-mturansk-test
-        destination: ocp-01-mturansk-test
+        path: deployments/ocm/ocp-01-mturansk-a1
+        destination: ocp-01-mturansk-a1
         syncWave: "4"
   template:
     metadata:
-      name: ocp-01-mturansk-test-{{component}}
+      name: ocp-01-mturansk-a1-{{component}}
       namespace: openshift-gitops
       annotations:
         argocd.argoproj.io/sync-wave: '{{syncWave}}'

--- a/operators/openshift-pipelines/ocp-01-mturansk-a1/kustomization.yaml
+++ b/operators/openshift-pipelines/ocp-01-mturansk-a1/kustomization.yaml
@@ -1,10 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: ocm-ocp-01-mturansk-test
+namespace: ocm-ocp-01-mturansk-a1
 
 commonAnnotations:
-  cluster: ocp-01-mturansk-test
+  cluster: ocp-01-mturansk-a1
   cluster-type: ocp
   version: "v0.0.1"
 

--- a/operators/openshift-pipelines/ocp-01-mturansk-a1/namespace.yaml
+++ b/operators/openshift-pipelines/ocp-01-mturansk-a1/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ocm-ocp-01-mturansk-a1
+  labels:
+    name: ocm-ocp-01-mturansk-a1

--- a/operators/openshift-pipelines/ocp-01-mturansk-test/namespace.yaml
+++ b/operators/openshift-pipelines/ocp-01-mturansk-test/namespace.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: ocm-ocp-01-mturansk-test
-  labels:
-    name: ocm-ocp-01-mturansk-test

--- a/pipelines/cloud-infrastructure-provisioning/ocp-01-mturansk-a1/cloud-infrastructure-provisioning.pipelinerun.yaml
+++ b/pipelines/cloud-infrastructure-provisioning/ocp-01-mturansk-a1/cloud-infrastructure-provisioning.pipelinerun.yaml
@@ -2,13 +2,13 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: cloud-infrastructure-provisioning-run
-  namespace: ocm-ocp-01-mturansk-test
+  namespace: ocm-ocp-01-mturansk-a1
 spec:
   pipelineRef:
     name: cloud-infrastructure-provisioning-pipeline
   params:
     - name: cluster-name
-      value: ocp-01-mturansk-test
+      value: ocp-01-mturansk-a1
     - name: cloud-provider
       value: aws
     - name: region

--- a/pipelines/cloud-infrastructure-provisioning/ocp-01-mturansk-a1/kustomization.yaml
+++ b/pipelines/cloud-infrastructure-provisioning/ocp-01-mturansk-a1/kustomization.yaml
@@ -1,10 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: ocm-ocp-01-mturansk-test
+namespace: ocm-ocp-01-mturansk-a1
 
 commonAnnotations:
-  cluster: ocp-01-mturansk-test
+  cluster: ocp-01-mturansk-a1
   cluster-type: ocp
   version: "v0.0.1"
 

--- a/pipelines/hello-world/ocp-01-mturansk-a1/hello-world.pipelinerun.yaml
+++ b/pipelines/hello-world/ocp-01-mturansk-a1/hello-world.pipelinerun.yaml
@@ -2,12 +2,12 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   name: hello-world-run
-  namespace: ocm-ocp-01-mturansk-test
+  namespace: ocm-ocp-01-mturansk-a1
 spec:
   pipelineRef:
     name: hello-world-pipeline
   params:
     - name: cluster-name
-      value: ocp-01-mturansk-test
+      value: ocp-01-mturansk-a1
     - name: region
       value: us-west-2

--- a/pipelines/hello-world/ocp-01-mturansk-a1/kustomization.yaml
+++ b/pipelines/hello-world/ocp-01-mturansk-a1/kustomization.yaml
@@ -1,10 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: ocm-ocp-01-mturansk-test
+namespace: ocm-ocp-01-mturansk-a1
 
 commonAnnotations:
-  cluster: ocp-01-mturansk-test
+  cluster: ocp-01-mturansk-a1
   cluster-type: ocp
   version: "v0.0.1"
 

--- a/regions/us-west-2/ocp-01-mturansk-a1/region.yaml
+++ b/regions/us-west-2/ocp-01-mturansk-a1/region.yaml
@@ -1,7 +1,7 @@
 apiVersion: regional.openshift.io/v1
 kind: RegionalCluster
 metadata:
-  name: ocp-01-mturansk-test
+  name: ocp-01-mturansk-a1
   namespace: us-west-2
 spec:
   type: ocp


### PR DESCRIPTION
…tstrap vault script reference

- Rename cluster configuration from ocp-01-mturansk-test to ocp-01-mturansk-a1
- Update all associated manifests, pipelines, and GitOps applications
- Fix bootstrap script vault integration reference (bootstrap.vault-integration.sh -> bootstrap.vault)
- Update cluster namespaces and deployment targets consistently

🤖 Generated with [Claude Code](https://claude.ai/code)