### PR TITLE
Add ocp-01-mturansk-jul29 cluster configuration for us-west-2 region

### DIFF
--- a/clusters/ocp-01-mturansk-jul29/install-config.yaml
+++ b/clusters/ocp-01-mturansk-jul29/install-config.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+metadata:
+  name: 'ocp-01-mturansk-jul29'
+baseDomain: rosa.mturansk-test.csu2.i3.devshift.org
+controlPlane:
+  architecture: amd64
+  hyperthreading: Enabled
+  name: master
+  replicas: 3
+  platform:
+    aws:
+      rootVolume:
+        iops: 4000
+        size: 100
+        type: io1
+      type: m5.2xlarge
+compute:
+  - hyperthreading: Enabled
+    architecture: amd64
+    name: 'worker'
+    replicas: 2
+    platform:
+      aws:
+        rootVolume:
+          iops: 2000
+          size: 100
+          type: io1
+        type: m5.2xlarge
+networking:
+  networkType: OVNKubernetes
+  clusterNetwork:
+    - cidr: 10.128.0.0/14
+      hostPrefix: 23
+  machineNetwork:
+    - cidr: 10.0.0.0/16
+  serviceNetwork:
+    - 172.30.0.0/16
+platform:
+  aws:
+    region: us-west-2
+pullSecret: "" # skip, hive will inject based on it's secrets

--- a/clusters/ocp-01-mturansk-jul29/klusterletaddonconfig.yaml
+++ b/clusters/ocp-01-mturansk-jul29/klusterletaddonconfig.yaml
@@ -1,0 +1,23 @@
+apiVersion: agent.open-cluster-management.io/v1
+kind: KlusterletAddonConfig
+metadata:
+  name: ocp-01-mturansk-jul29
+  namespace: ocp-01-mturansk-jul29
+spec:
+  applicationManager:
+    enabled: true
+  certPolicyController:
+    enabled: true
+  clusterLabels:
+    cloud: Amazon
+    name: ocp-01-mturansk-jul29
+    vendor: OpenShift
+    region: us-west-2
+  clusterName: ocp-01-mturansk-jul29
+  clusterNamespace: ocp-01-mturansk-jul29
+  policyController:
+    enabled: true
+  searchCollector:
+    enabled: true
+  iamPolicyController:
+    enabled: true

--- a/clusters/ocp-01-mturansk-jul29/kustomization.yaml
+++ b/clusters/ocp-01-mturansk-jul29/kustomization.yaml
@@ -1,0 +1,108 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - klusterletaddonconfig.yaml
+  - ../../bases/clusters
+
+# This will disable name hashing for all generators in this file
+generatorOptions:
+  disableNameSuffixHash: true
+
+secretGenerator:
+  - name: install-config
+    namespace: ocp-01-mturansk-jul29
+    files:
+      - install-config.yaml
+
+patches:
+  - target:
+      kind: ClusterDeployment
+      version: v1
+      group: hive.openshift.io
+    patch: |
+      - op: replace
+        path: /metadata/namespace
+        value: ocp-01-mturansk-jul29
+      - op: replace
+        path: /metadata/name
+        value: ocp-01-mturansk-jul29
+      - op: replace
+        path: /spec/clusterName
+        value: ocp-01-mturansk-jul29
+      - op: replace
+        path: /spec/platform/aws/region
+        value: us-west-2
+  - target:
+      kind: ManagedCluster
+      version: v1
+      group: cluster.open-cluster-management.io
+    patch: |
+      - op: replace
+        path: /metadata/namespace
+        value: ocp-01-mturansk-jul29
+      - op: replace
+        path: /metadata/name
+        value: ocp-01-mturansk-jul29
+      - op: replace
+        path: /metadata/labels/name
+        value: ocp-01-mturansk-jul29
+      - op: replace
+        path: /metadata/labels/region
+        value: us-west-2
+  - target:
+      kind: MachinePool
+      version: v1
+      group: hive.openshift.io
+    patch: |
+      - op: replace
+        path: /metadata/namespace
+        value: ocp-01-mturansk-jul29
+      - op: replace
+        path: /spec/clusterDeploymentRef/name
+        value: ocp-01-mturansk-jul29
+      - op: replace
+        path: /metadata/name
+        value: ocp-01-mturansk-jul29-worker
+  - target:
+      kind: KlusterletAddonConfig
+      version: v1
+      group: agent.open-cluster-management.io
+    patch: |
+      - op: replace
+        path: /metadata/namespace
+        value: ocp-01-mturansk-jul29
+      - op: replace
+        path: /metadata/name
+        value: ocp-01-mturansk-jul29
+      - op: replace
+        path: /spec/clusterLabels/name
+        value: ocp-01-mturansk-jul29
+      - op: replace
+        path: /spec/clusterNamespace
+        value: ocp-01-mturansk-jul29
+      - op: replace
+        path: /spec/clusterName
+        value: ocp-01-mturansk-jul29
+  - target:
+      kind: ExternalSecret
+      version: v1
+      group: external-secrets.io
+      name: aws-credentials
+    patch: |
+      - op: replace
+        path: /metadata/namespace
+        value: ocp-01-mturansk-jul29
+  - target:
+      kind: ExternalSecret
+      version: v1
+      group: external-secrets.io
+      name: pull-secret
+    patch: |
+      - op: replace
+        path: /metadata/namespace
+        value: ocp-01-mturansk-jul29
+      - op: replace
+        path: /spec/target/template/type
+        value: kubernetes.io/dockerconfigjson

--- a/clusters/ocp-01-mturansk-jul29/namespace.yaml
+++ b/clusters/ocp-01-mturansk-jul29/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ocp-01-mturansk-jul29
+  labels:
+    name: ocp-01-mturansk-jul29

--- a/deployments/ocm/ocp-01-mturansk-jul29/kustomization.yaml
+++ b/deployments/ocm/ocp-01-mturansk-jul29/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ocm-ocp-01-mturansk-jul29
+
+resources:
+  - ../../../bases/ocm
+  - namespace.yaml

--- a/deployments/ocm/ocp-01-mturansk-jul29/namespace.yaml
+++ b/deployments/ocm/ocp-01-mturansk-jul29/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ocm-ocp-01-mturansk-jul29
+  labels:
+    name: ocm-ocp-01-mturansk-jul29

--- a/gitops-applications/kustomization.yaml
+++ b/gitops-applications/kustomization.yaml
@@ -8,6 +8,8 @@ resources:
 
 # ADD CLUSTERS HERE
 
+- ./ocp-01-mturansk-jul29.yaml
+
 
 
 

--- a/gitops-applications/ocp-01-mturansk-jul29.yaml
+++ b/gitops-applications/ocp-01-mturansk-jul29.yaml
@@ -1,0 +1,48 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: ocp-01-mturansk-jul29-applications
+  namespace: openshift-gitops
+spec:
+  generators:
+  - list:
+      elements:
+      - component: cluster
+        path: clusters/ocp-01-mturansk-jul29
+        destination: https://kubernetes.default.svc
+        syncWave: "1"
+      - component: operators
+        path: operators/openshift-pipelines/ocp-01-mturansk-jul29
+        destination: ocp-01-mturansk-jul29
+        syncWave: "2"
+      - component: pipelines-hello-world
+        path: pipelines/hello-world/ocp-01-mturansk-jul29
+        destination: ocp-01-mturansk-jul29
+        syncWave: "3"
+      - component: pipelines-cloud-infrastructure-provisioning
+        path: pipelines/cloud-infrastructure-provisioning/ocp-01-mturansk-jul29
+        destination: ocp-01-mturansk-jul29
+        syncWave: "3"
+      - component: deployments-ocm
+        path: deployments/ocm/ocp-01-mturansk-jul29
+        destination: ocp-01-mturansk-jul29
+        syncWave: "4"
+  template:
+    metadata:
+      name: ocp-01-mturansk-jul29-{{component}}
+      namespace: openshift-gitops
+      annotations:
+        argocd.argoproj.io/sync-wave: '{{syncWave}}'
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/openshift-online/bootstrap
+        path: '{{path}}'
+        targetRevision: main
+      destination:
+        server: '{{destination}}'
+      syncPolicy:
+        automated:
+          selfHeal: true
+          allowEmpty: false
+        prune: false

--- a/operators/openshift-pipelines/ocp-01-mturansk-jul29/kustomization.yaml
+++ b/operators/openshift-pipelines/ocp-01-mturansk-jul29/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ocm-ocp-01-mturansk-jul29
+
+commonAnnotations:
+  cluster: ocp-01-mturansk-jul29
+  cluster-type: ocp
+  version: "v0.0.1"
+
+resources:
+  - ../global/overlays/pipelines-operator-only
+  - namespace.yaml

--- a/operators/openshift-pipelines/ocp-01-mturansk-jul29/namespace.yaml
+++ b/operators/openshift-pipelines/ocp-01-mturansk-jul29/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ocm-ocp-01-mturansk-jul29
+  labels:
+    name: ocm-ocp-01-mturansk-jul29

--- a/pipelines/cloud-infrastructure-provisioning/ocp-01-mturansk-jul29/cloud-infrastructure-provisioning.pipelinerun.yaml
+++ b/pipelines/cloud-infrastructure-provisioning/ocp-01-mturansk-jul29/cloud-infrastructure-provisioning.pipelinerun.yaml
@@ -1,0 +1,28 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: cloud-infrastructure-provisioning-run
+  namespace: ocm-ocp-01-mturansk-jul29
+spec:
+  pipelineRef:
+    name: cloud-infrastructure-provisioning-pipeline
+  params:
+    - name: cluster-name
+      value: ocp-01-mturansk-jul29
+    - name: cloud-provider
+      value: aws
+    - name: region
+      value: us-west-2
+    - name: instance-type
+      value: m5.2xlarge
+    - name: node-count
+      value: "2"
+  workspaces:
+    - name: shared-workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi

--- a/pipelines/cloud-infrastructure-provisioning/ocp-01-mturansk-jul29/kustomization.yaml
+++ b/pipelines/cloud-infrastructure-provisioning/ocp-01-mturansk-jul29/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ocm-ocp-01-mturansk-jul29
+
+commonAnnotations:
+  cluster: ocp-01-mturansk-jul29
+  cluster-type: ocp
+  version: "v0.0.1"
+
+resources:
+  - cloud-infrastructure-provisioning.pipelinerun.yaml
+
+components:
+  - ../../../bases/pipelines/cloud-infrastructure-provisioning

--- a/pipelines/hello-world/ocp-01-mturansk-jul29/hello-world.pipelinerun.yaml
+++ b/pipelines/hello-world/ocp-01-mturansk-jul29/hello-world.pipelinerun.yaml
@@ -1,0 +1,13 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: hello-world-run
+  namespace: ocm-ocp-01-mturansk-jul29
+spec:
+  pipelineRef:
+    name: hello-world-pipeline
+  params:
+    - name: cluster-name
+      value: ocp-01-mturansk-jul29
+    - name: region
+      value: us-west-2

--- a/pipelines/hello-world/ocp-01-mturansk-jul29/kustomization.yaml
+++ b/pipelines/hello-world/ocp-01-mturansk-jul29/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ocm-ocp-01-mturansk-jul29
+
+commonAnnotations:
+  cluster: ocp-01-mturansk-jul29
+  cluster-type: ocp
+  version: "v0.0.1"
+
+resources:
+  - hello-world.pipelinerun.yaml
+
+components:
+  - ../../../bases/pipelines/hello-world

--- a/regions/us-west-2/ocp-01-mturansk-jul29/region.yaml
+++ b/regions/us-west-2/ocp-01-mturansk-jul29/region.yaml
@@ -1,0 +1,19 @@
+apiVersion: regional.openshift.io/v1
+kind: RegionalCluster
+metadata:
+  name: ocp-01-mturansk-jul29
+  namespace: us-west-2
+spec:
+  type: ocp
+  region: us-west-2
+  domain: rosa.mturansk-test.csu2.i3.devshift.org
+  
+  # Minimal compute config
+  compute:
+    instanceType: m5.2xlarge
+    replicas: 2
+    
+  # Type-specific configuration
+  openshift:
+    version: "4.15"
+    channel: stable


### PR DESCRIPTION
This commit adds a complete cluster configuration for ocp-01-mturansk-jul29 including:
- Cluster deployment manifests with install-config for m5.2xlarge instances
- OpenShift Pipelines operator configuration
- Hello-world and cloud-infrastructure-provisioning pipeline runs
- OCM deployment configuration
- GitOps ApplicationSet for automated management

🤖 Generated with [Claude Code](https://claude.ai/code)