### PR TITLE
Update cluster destinations and pin pipelines operator version

### DIFF
--- a/gitops-applications/ocp-01-mturansk-jul29.yaml
+++ b/gitops-applications/ocp-01-mturansk-jul29.yaml
@@ -13,19 +13,19 @@ spec:
         syncWave: "1"
       - component: operators
         path: operators/openshift-pipelines/ocp-01-mturansk-jul29
-        destination: ocp-01-mturansk-jul29
+        destination: https://api.ocp-01-mturansk-jul29.rosa.mturansk-test.csu2.i3.devshift.org:6443
         syncWave: "2"
       - component: pipelines-hello-world
         path: pipelines/hello-world/ocp-01-mturansk-jul29
-        destination: ocp-01-mturansk-jul29
+        destination: https://api.ocp-01-mturansk-jul29.rosa.mturansk-test.csu2.i3.devshift.org:6443
         syncWave: "3"
       - component: pipelines-cloud-infrastructure-provisioning
         path: pipelines/cloud-infrastructure-provisioning/ocp-01-mturansk-jul29
-        destination: ocp-01-mturansk-jul29
+        destination: https://api.ocp-01-mturansk-jul29.rosa.mturansk-test.csu2.i3.devshift.org:6443
         syncWave: "3"
       - component: deployments-ocm
         path: deployments/ocm/ocp-01-mturansk-jul29
-        destination: ocp-01-mturansk-jul29
+        destination: https://api.ocp-01-mturansk-jul29.rosa.mturansk-test.csu2.i3.devshift.org:6443
         syncWave: "4"
   template:
     metadata:

--- a/operators/openshift-pipelines/global/overlays/pipelines-operator-only/subscription.yaml
+++ b/operators/openshift-pipelines/global/overlays/pipelines-operator-only/subscription.yaml
@@ -9,3 +9,4 @@ spec:
   name: openshift-pipelines-operator-rh
   source: redhat-operators
   sourceNamespace: openshift-marketplace
+  startingCSV: openshift-pipelines-operator-rh.v1.18.1


### PR DESCRIPTION
- Change destinations from cluster names to full API URLs in ocp-01-mturansk-jul29 config
- Pin openshift-pipelines-operator to v1.18.1 for version consistency

🤖 Generated with [Claude Code](https://claude.ai/code)