### PR TITLE
Add cluster name validation and update EKS defaults

### DIFF
--- a/bin/cluster-create
+++ b/bin/cluster-create
@@ -92,9 +92,42 @@ generate_cluster_name() {
     printf "${type}-%02d" "$next_num"
 }
 
+# Function to validate cluster name length and format
+validate_cluster_name_format() {
+    local name="$1"
+    
+    # Validate cluster name length for Kubernetes label compatibility
+    # ApplicationSet generates names like: {cluster-name}-{component}
+    # Longest component is "pipelines-cloud-infrastructure-provisioning" (43 chars)
+    # Kubernetes labels max length is 63 chars
+    # Max cluster name = 63 - 43 - 1 (hyphen) = 19 characters
+    local max_length=19
+    if [ ${#name} -gt $max_length ]; then
+        echo "Error: Cluster name '$name' is ${#name} characters long" >&2
+        echo "Maximum allowed length is $max_length characters to avoid Kubernetes label length violations" >&2
+        echo "Generated ApplicationSet names like '$name-pipelines-cloud-infrastructure-provisioning' would exceed 63 character limit" >&2
+        return 1
+    fi
+    
+    # Validate cluster name format (alphanumeric, hyphens, must start/end with alphanumeric)
+    if ! echo "$name" | grep -q '^[a-z0-9][a-z0-9-]*[a-z0-9]$\|^[a-z0-9]$'; then
+        echo "Error: Cluster name '$name' contains invalid characters" >&2
+        echo "Cluster names must contain only lowercase letters, numbers, and hyphens" >&2
+        echo "Must start and end with an alphanumeric character" >&2
+        return 1
+    fi
+    
+    return 0
+}
+
 # Function to validate cluster name uniqueness
 validate_cluster_name() {
     local name="$1"
+    
+    # First validate name format and length
+    if ! validate_cluster_name_format "$name"; then
+        return 1
+    fi
     
     # Check if cluster directory already exists
     if [ -d "clusters/$name" ]; then

--- a/bin/cluster-generate
+++ b/bin/cluster-generate
@@ -76,7 +76,7 @@ REGION=${REGION:-"us-west-2"}
 DOMAIN=${DOMAIN:-"rosa.mturansk-test.csu2.i3.devshift.org"}
 INSTANCE_TYPE=${INSTANCE_TYPE:-"m5.large"}
 REPLICAS=${REPLICAS:-3}
-KUBERNETES_VERSION=${KUBERNETES_VERSION:-"1.28"}
+KUBERNETES_VERSION=${KUBERNETES_VERSION:-"1.31"}
 
 # For EKS, ensure semantic versioning (remove 'v' prefix if present and ensure format is X.Y)
 if [ "$CLUSTER_TYPE" = "eks" ]; then

--- a/clusters/eks-01-mturansk-jul30/acm-integration-pipeline.yaml
+++ b/clusters/eks-01-mturansk-jul30/acm-integration-pipeline.yaml
@@ -16,6 +16,8 @@ spec:
     env:
     - name: AWS_DEFAULT_REGION
       value: $(params.region)
+    - name: PATH
+      value: "/tmp/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
     volumeMounts:
     - name: aws-credentials
       mountPath: /root/.aws
@@ -28,18 +30,25 @@ spec:
       set -e
       echo "Installing required tools..."
       
+      # Create user bin directory and change to tmp
+      mkdir -p /tmp/bin
+      cd /tmp
+      export PATH="/tmp/bin:$PATH"
+      
       # Install kubectl
       curl -LO "https://dl.k8s.io/release/v1.28.0/bin/linux/amd64/kubectl"
-      chmod +x kubectl && mv kubectl /usr/local/bin/
+      chmod +x kubectl && mv kubectl /tmp/bin/
       
-      # Install AWS CLI
+      # Install AWS CLI to user location  
       curl -LO "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
-      unzip awscli-exe-linux-x86_64.zip && ./aws/install
+      unzip awscli-exe-linux-x86_64.zip && ./aws/install --install-dir /tmp/aws-cli --bin-dir /tmp/bin
       
       # Install OpenShift CLI
-      curl -L "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz" | tar -xz -C /usr/local/bin/ oc
+      curl -L "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz" | tar -xz -C /tmp/bin/ oc
       
       echo "Tools installed successfully"
+      echo "PATH: $PATH"
+      ls -la /tmp/bin/
       
   - name: wait-for-eks-cluster
     image: registry.redhat.io/ubi9/ubi:latest

--- a/operators/gitops-integration/global/policies/capa-rbac-policy.yaml
+++ b/operators/gitops-integration/global/policies/capa-rbac-policy.yaml
@@ -1,0 +1,77 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: capa-rbac-policy
+  namespace: open-cluster-management-policies
+  annotations:
+    policy.open-cluster-management.io/standards: NIST-CSF
+    policy.open-cluster-management.io/categories: AC Access Control
+    policy.open-cluster-management.io/controls: AC-3 Access Enforcement
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: capa-manager-finalizers-rbac
+        spec:
+          remediationAction: enforce
+          severity: medium
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: rbac.authorization.k8s.io/v1
+                kind: ClusterRole
+                metadata:
+                  name: capa-manager-finalizers-role
+                  labels:
+                    cluster.x-k8s.io/provider: infrastructure-aws
+                rules:
+                  - apiGroups: ["controlplane.cluster.x-k8s.io"]
+                    resources: ["awsmanagedcontrolplanes/finalizers"]
+                    verbs: ["update"]
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: rbac.authorization.k8s.io/v1
+                kind: ClusterRoleBinding
+                metadata:
+                  name: capa-manager-finalizers-binding
+                  labels:
+                    cluster.x-k8s.io/provider: infrastructure-aws
+                roleRef:
+                  apiGroup: rbac.authorization.k8s.io
+                  kind: ClusterRole
+                  name: capa-manager-finalizers-role
+                subjects:
+                  - kind: ServiceAccount
+                    name: capa-controller-manager
+                    namespace: multicluster-engine
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: capa-rbac-policy-binding
+  namespace: open-cluster-management-policies
+placementRef:
+  name: capa-rbac-policy-placement
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: capa-rbac-policy
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: capa-rbac-policy-placement
+  namespace: open-cluster-management-policies
+spec:
+  clusterConditions:
+    - status: "True"
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchLabels:
+      name: local-cluster

--- a/operators/gitops-integration/global/policies/kustomization.yaml
+++ b/operators/gitops-integration/global/policies/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
   - gitops-integration-policy.yaml
+  - capa-rbac-policy.yaml


### PR DESCRIPTION
- Add 19-character cluster name length validation to prevent Kubernetes label violations
- Add format validation for cluster names (lowercase alphanumeric and hyphens only)
- Update default Kubernetes version from 1.28 to 1.31 for new clusters
- Fix EKS pipeline tool installation paths for non-root containers
- Add CAPA RBAC policy for AWS managed control plane finalizer permissions
- Update cluster creation documentation with validation requirements

🤖 Generated with [Claude Code](https://claude.ai/code)