### PR TITLE
Update ACM and GitOps integration with sync waves and annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
 # Go module cache
 acme/pkg/mod/
-secrets/
-.secrets/
-.idea/
 .claude/
+.idea/
+.openshift/
+.secrets/
 .tmp/
+secrets/
 STATUS.md
 clusters_backup/

--- a/gitops-applications/global/advanced-cluster-management.application.yaml
+++ b/gitops-applications/global/advanced-cluster-management.application.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: advanced-cluster-management
   namespace: openshift-gitops
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   destination:
     name: in-cluster

--- a/operators/advanced-cluster-management/global/instance/base/multiclusterhub.yaml
+++ b/operators/advanced-cluster-management/global/instance/base/multiclusterhub.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: open-cluster-management
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   availabilityConfig: High
   enableClusterBackup: false

--- a/operators/advanced-cluster-management/global/instance/base/subscription-admin.yaml
+++ b/operators/advanced-cluster-management/global/instance/base/subscription-admin.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: open-cluster-management:subscription-admin
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/operators/advanced-cluster-management/global/operator/base/namespace.yaml
+++ b/operators/advanced-cluster-management/global/operator/base/namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/display-name: "Advanced Cluster Management for Kubernetes"
+    argocd.argoproj.io/sync-wave: "-1"
   labels:
     openshift.io/cluster-monitoring: 'true'
     argocd.argoproj.io/managed-by: openshift-gitops

--- a/operators/advanced-cluster-management/global/operator/base/operator-group.yaml
+++ b/operators/advanced-cluster-management/global/operator/base/operator-group.yaml
@@ -3,6 +3,8 @@ kind: OperatorGroup
 metadata:
   name: advanced-cluster-management
   namespace: open-cluster-management
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 spec:
   targetNamespaces:
     - open-cluster-management

--- a/operators/advanced-cluster-management/global/operator/base/subscription.yaml
+++ b/operators/advanced-cluster-management/global/operator/base/subscription.yaml
@@ -3,6 +3,8 @@ kind: Subscription
 metadata:
   name: advanced-cluster-management
   namespace: open-cluster-management
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 spec:
   channel: patch-me-see-overlays-dir
   installPlanApproval: Automatic

--- a/operators/gitops-integration/global/base/gitopscluster.yaml
+++ b/operators/gitops-integration/global/base/gitopscluster.yaml
@@ -3,6 +3,8 @@ kind: GitOpsCluster
 metadata:
   name: gitops-cluster
   namespace: openshift-gitops
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   argoServer:
     cluster: local-cluster

--- a/operators/gitops-integration/global/base/managedclustersetbinding.yaml
+++ b/operators/gitops-integration/global/base/managedclustersetbinding.yaml
@@ -3,5 +3,7 @@ kind: ManagedClusterSetBinding
 metadata:
   name: global
   namespace: openshift-gitops
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   clusterSet: global

--- a/operators/gitops-integration/global/base/placement.yaml
+++ b/operators/gitops-integration/global/base/placement.yaml
@@ -3,6 +3,8 @@ kind: Placement
 metadata:
   name: gitops-cluster-placement
   namespace: openshift-gitops
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   clusterSets:
     - global

--- a/operators/gitops-integration/global/policies/capa-rbac-policy.yaml
+++ b/operators/gitops-integration/global/policies/capa-rbac-policy.yaml
@@ -7,6 +7,7 @@ metadata:
     policy.open-cluster-management.io/standards: NIST-CSF
     policy.open-cluster-management.io/categories: AC Access Control
     policy.open-cluster-management.io/controls: AC-3 Access Enforcement
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   remediationAction: enforce
   disabled: false
@@ -54,6 +55,8 @@ kind: PlacementBinding
 metadata:
   name: capa-rbac-policy-binding
   namespace: open-cluster-management-policies
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 placementRef:
   name: capa-rbac-policy-placement
   kind: PlacementRule
@@ -68,6 +71,8 @@ kind: PlacementRule
 metadata:
   name: capa-rbac-policy-placement
   namespace: open-cluster-management-policies
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   clusterConditions:
     - status: "True"

--- a/operators/gitops-integration/global/policies/gitops-integration-policy.yaml
+++ b/operators/gitops-integration/global/policies/gitops-integration-policy.yaml
@@ -7,6 +7,7 @@ metadata:
     policy.open-cluster-management.io/standards: NIST-CSF
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   remediationAction: enforce
   disabled: false
@@ -84,6 +85,8 @@ kind: PlacementBinding
 metadata:
   name: gitops-integration-policy-binding
   namespace: open-cluster-management-policies
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 placementRef:
   name: gitops-integration-policy-placement
   kind: PlacementRule
@@ -98,6 +101,8 @@ kind: PlacementRule
 metadata:
   name: gitops-integration-policy-placement
   namespace: open-cluster-management-policies
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   clusterConditions:
     - status: "True"


### PR DESCRIPTION
Adds ArgoCD sync wave annotations to control deployment order and improves resource synchronization:
- Added sync waves to ACM operator resources (-1) and instances (0)
- Added sync waves to GitOps integration resources (1)
- Updated .gitignore organization
- Added SkipDryRunOnMissingResource annotations

🤖 Generated with [Claude Code](https://claude.ai/code)