### PR TITLE
Update ACM sync waves to use 0,1,2 progression

### DIFF
--- a/operators/advanced-cluster-management/global/instance/base/multiclusterhub.yaml
+++ b/operators/advanced-cluster-management/global/instance/base/multiclusterhub.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: open-cluster-management
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: "0"
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   availabilityConfig: High
   enableClusterBackup: false

--- a/operators/advanced-cluster-management/global/instance/base/subscription-admin.yaml
+++ b/operators/advanced-cluster-management/global/instance/base/subscription-admin.yaml
@@ -3,7 +3,7 @@ kind: ClusterRoleBinding
 metadata:
   name: open-cluster-management:subscription-admin
   annotations:
-    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-wave: "0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/operators/advanced-cluster-management/global/operator/base/namespace.yaml
+++ b/operators/advanced-cluster-management/global/operator/base/namespace.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/display-name: "Advanced Cluster Management for Kubernetes"
-    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-wave: "0"
   labels:
     openshift.io/cluster-monitoring: 'true'
     argocd.argoproj.io/managed-by: openshift-gitops

--- a/operators/advanced-cluster-management/global/operator/base/operator-group.yaml
+++ b/operators/advanced-cluster-management/global/operator/base/operator-group.yaml
@@ -4,7 +4,7 @@ metadata:
   name: advanced-cluster-management
   namespace: open-cluster-management
   annotations:
-    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   targetNamespaces:
     - open-cluster-management

--- a/operators/advanced-cluster-management/global/operator/base/subscription.yaml
+++ b/operators/advanced-cluster-management/global/operator/base/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: advanced-cluster-management
   namespace: open-cluster-management
   annotations:
-    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   channel: patch-me-see-overlays-dir
   installPlanApproval: Automatic

--- a/operators/gitops-integration/global/base/gitopscluster.yaml
+++ b/operators/gitops-integration/global/base/gitopscluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gitops-cluster
   namespace: openshift-gitops
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   argoServer:
     cluster: local-cluster

--- a/operators/gitops-integration/global/base/managedclustersetbinding.yaml
+++ b/operators/gitops-integration/global/base/managedclustersetbinding.yaml
@@ -4,6 +4,6 @@ metadata:
   name: global
   namespace: openshift-gitops
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   clusterSet: global

--- a/operators/gitops-integration/global/base/placement.yaml
+++ b/operators/gitops-integration/global/base/placement.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gitops-cluster-placement
   namespace: openshift-gitops
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   clusterSets:
     - global

--- a/operators/gitops-integration/global/policies/capa-rbac-policy.yaml
+++ b/operators/gitops-integration/global/policies/capa-rbac-policy.yaml
@@ -7,7 +7,7 @@ metadata:
     policy.open-cluster-management.io/standards: NIST-CSF
     policy.open-cluster-management.io/categories: AC Access Control
     policy.open-cluster-management.io/controls: AC-3 Access Enforcement
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   remediationAction: enforce
   disabled: false
@@ -56,7 +56,7 @@ metadata:
   name: capa-rbac-policy-binding
   namespace: open-cluster-management-policies
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "2"
 placementRef:
   name: capa-rbac-policy-placement
   kind: PlacementRule
@@ -72,7 +72,7 @@ metadata:
   name: capa-rbac-policy-placement
   namespace: open-cluster-management-policies
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   clusterConditions:
     - status: "True"

--- a/operators/gitops-integration/global/policies/gitops-integration-policy.yaml
+++ b/operators/gitops-integration/global/policies/gitops-integration-policy.yaml
@@ -7,7 +7,7 @@ metadata:
     policy.open-cluster-management.io/standards: NIST-CSF
     policy.open-cluster-management.io/categories: CM Configuration Management
     policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   remediationAction: enforce
   disabled: false
@@ -86,7 +86,7 @@ metadata:
   name: gitops-integration-policy-binding
   namespace: open-cluster-management-policies
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "2"
 placementRef:
   name: gitops-integration-policy-placement
   kind: PlacementRule
@@ -102,7 +102,7 @@ metadata:
   name: gitops-integration-policy-placement
   namespace: open-cluster-management-policies
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   clusterConditions:
     - status: "True"


### PR DESCRIPTION
- Wave 0: Namespace, OperatorGroup, Subscription, ClusterRoleBinding (install ACM operator)
- Wave 1: MultiClusterHub instance (requires ACM CRDs)
- Wave 2: Policy, PlacementRule, PlacementBinding, GitOpsCluster resources (requires ACM CRDs)

🤖 Generated with [Claude Code](https://claude.ai/code)